### PR TITLE
fix(docs): fix typos and inconsistent wordings in docs

### DIFF
--- a/docs/release-notes-v3.md
+++ b/docs/release-notes-v3.md
@@ -30,15 +30,15 @@ const alova = createAlova({
 Now you can directly use `alova/client` and `alova/server` as long as you install `alova`.
 
 ```javascript
-import vueHook from 'alova/vue';
-import reactHook from 'alova/react';
-import svelteHook from 'alova/svelte';
-import vueDemiHook from 'alova/vue-demi';
+import VueHook from 'alova/vue';
+import ReactHook from 'alova/react';
+import SvelteHook from 'alova/svelte';
+import VueDemiHook from 'alova/vue-demi';
 import { useRequest, useWatcher, usePagination } from 'alova/client';
 import adapterFetch from 'alova/fetch';
 
 const alova = createAlova({
-  statesHook: vueHook,
+  statesHook: VueHook,
   requestAdapter: adapterFetch()
 });
 const { data, loading, error } = useRequest(alova.Get('/api/user'));
@@ -135,7 +135,7 @@ const alovaInst = createAlova({
 An example of handling cache avalanche, solved by adding random expiration time
 
 ```javascript
-alova.Get('/xxx', {
+alovaInst.Get('/xxx', {
   cacheFor: {
     expire: 100000 * Math.floor(Math.random() * 1000),
     mode: 'restore'

--- a/docs/tutorial/02-getting-started/02-quick-start.md
+++ b/docs/tutorial/02-getting-started/02-quick-start.md
@@ -74,7 +74,7 @@ const alovaInstance = createAlova({
 const { createAlova } = require('alova');
 const adapterFetch = require('alova/fetch');
 
-const alova = createAlova({
+const alovaInstance = createAlova({
   requestAdapter: adapterFetch(),
   responded: response => response.json()
 });
@@ -89,7 +89,7 @@ const alova = createAlova({
 import { createAlova } from 'npm:alova';
 import adapterFetch from 'npm:alova/fetch';
 
-const alova = createAlova({
+const alovaInstance = createAlova({
   requestAdapter: adapterFetch(),
   responded: response => response.json()
 });

--- a/docs/tutorial/02-getting-started/03-basic/07-combine-framework.md
+++ b/docs/tutorial/02-getting-started/03-basic/07-combine-framework.md
@@ -255,7 +255,7 @@ const { data } = useWatcher(() => todoListGetter, [userInfo]);
 The data value will receive the transformed data format.
 
 ```typescript
-type data = {
+type Data = {
   // ...
   statusText: 'Completed' | 'In progress';
 }[];

--- a/docs/tutorial/02-getting-started/09-extension-integration.md
+++ b/docs/tutorial/02-getting-started/09-extension-integration.md
@@ -233,13 +233,13 @@ The contents of the `index` file are as follows:
 ```js
 import { createAlova } from 'alova';
 import GlobalFetch from 'alova/GlobalFetch';
-import vueHook from 'alova/vue';
+import VueHook from 'alova/vue';
 import { createApis, withConfigType } from './createApis';
 
 // The alova instance corresponding to the current api, you can modify the parameters here.
 export const alovaInstance = createAlova({
   baseURL: 'server parameter in openapi file',
-  statesHook: vueHook,
+  statesHook: VueHook,
   requestAdapter: GlobalFetch(),
   beforeRequest: method => {},
   responded: res => {

--- a/docs/tutorial/06-advanced/01-in-depth/10-typescript.md
+++ b/docs/tutorial/06-advanced/01-in-depth/10-typescript.md
@@ -71,7 +71,7 @@ const {
   loading, // Accessor<boolean>
   data, // Accessor<{ data: any }>
   error // Accessor<Error>
-} = useRequest(svelteAlova.Get<{ data: any }>('/todo/list'));
+} = useRequest(solidAlova.Get<{ data: any }>('/todo/list'));
 ```
 
 </TabItem>

--- a/docs/tutorial/06-advanced/02-custom/01-http-adapter.md
+++ b/docs/tutorial/06-advanced/02-custom/01-http-adapter.md
@@ -162,7 +162,7 @@ The global `beforeRequest`, `responded` interceptors, and the types of configura
 ```javascript
 import type { AlovaRequestAdapter } from 'alova';
 
-export type adapterFetch = () => AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
+export type AdapterFetch = () => AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
 ```
 
 The generic parameters in `AlovaRequestAdapter` are values ​​of three types: `RequestConfig`, `Response`, and `ResponseHeader`, which are automatically inferred to the types given by the request adapter in global interceptors, method instance configurations, etc.

--- a/docs/tutorial/07-project/01-best-practice/01-manage-apis.md
+++ b/docs/tutorial/07-project/01-best-practice/01-manage-apis.md
@@ -73,7 +73,7 @@ export const orderAlova = createAlova({
 
 // upload alova instance
 export const uploadAlova = createAlova({
-  baseURL: 'https://api-order.alovajs.org',
+  baseURL: 'https://api-upload.alovajs.org',
   statesHook: VueHook,
   requestAdapter: axiosRequestAdapter()
 });

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/release-notes-v3.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/release-notes-v3.md
@@ -28,15 +28,15 @@ const alova = createAlova({
 现在只要安装`alova`就可以直接使用`alova/client`和`alova/server`。
 
 ```javascript
-import vueHook from 'alova/vue';
-import reactHook from 'alova/react';
-import svelteHook from 'alova/svelte';
-import vueDemiHook from 'alova/vue-demi';
+import VueHook from 'alova/vue';
+import ReactHook from 'alova/react';
+import SvelteHook from 'alova/svelte';
+import VueDemiHook from 'alova/vue-demi';
 import { useRequest, useWatcher, usePagination } from 'alova/client';
 import adapterFetch from 'alova/fetch';
 
 const alova = createAlova({
-  statesHook: vueHook,
+  statesHook: VueHook,
   requestAdapter: adapterFetch()
 });
 const { data, loading, error } = useRequest(alova.Get('/api/user'));
@@ -132,7 +132,7 @@ const alovaInst = createAlova({
 一个处理缓存雪崩的示例，通过添加随机过期时间解决
 
 ```javascript
-alova.Get('/xxx', {
+alovaInst.Get('/xxx', {
   cacheFor: {
     expire: 100000 * Math.floor(Math.random() * 1000),
     mode: 'restore'

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/02-getting-started/02-quick-start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/02-getting-started/02-quick-start.md
@@ -74,7 +74,7 @@ const alovaInstance = createAlova({
 const { createAlova } = require('alova');
 const adapterFetch = require('alova/fetch');
 
-const alova = createAlova({
+const alovaInstance = createAlova({
   requestAdapter: adapterFetch(),
   responded: response => response.json()
 });
@@ -89,7 +89,7 @@ const alova = createAlova({
 import { createAlova } from 'npm:alova';
 import adapterFetch from 'npm:alova/fetch';
 
-const alova = createAlova({
+const alovaInstance = createAlova({
   requestAdapter: adapterFetch(),
   responded: response => response.json()
 });

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/02-getting-started/03-basic/07-combine-framework.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/02-getting-started/03-basic/07-combine-framework.md
@@ -253,7 +253,7 @@ const { data } = useRequest(todoListGetter);
 data 值将接收到转换后的数据格式。
 
 ```typescript
-type data = {
+type Data = {
   // ...
   statusText: '已完成' | '进行中';
 }[];

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/02-getting-started/09-extension-integration.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/02-getting-started/09-extension-integration.md
@@ -231,13 +231,13 @@ useRequest(() =>
 ```js
 import { createAlova } from 'alova';
 import GlobalFetch from 'alova/GlobalFetch';
-import vueHook from 'alova/vue';
+import VueHook from 'alova/vue';
 import { createApis, withConfigType } from './createApis';
 
 // 当前api对应的alova实例，你可以在此修改参数。
 export const alovaInstance = createAlova({
   baseURL: 'openapi文件中的server参数',
-  statesHook: vueHook,
+  statesHook: VueHook,
   requestAdapter: GlobalFetch(),
   beforeRequest: method => {},
   responded: res => {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/06-advanced/01-in-depth/10-typescript.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/06-advanced/01-in-depth/10-typescript.md
@@ -74,7 +74,7 @@ const {
   loading, // Accessor<boolean>
   data, // Accessor<{ data: any }>
   error // Accessor<Error>
-} = useRequest(svelteAlova.Get<{ data: any }>('/todo/list'));
+} = useRequest(solidAlova.Get<{ data: any }>('/todo/list'));
 ```
 
 </TabItem>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/06-advanced/02-custom/01-http-adapter.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/06-advanced/02-custom/01-http-adapter.md
@@ -162,7 +162,7 @@ function XMLHttpRequestAdapter(requestElements, methodInstance) {
 ```javascript
 import type { AlovaRequestAdapter } from 'alova';
 
-export type adapterFetch = () => AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
+export type AdapterFetch = () => AlovaRequestAdapter<FetchRequestInit, Response, Headers>;
 ```
 
 在`AlovaRequestAdapter`中的泛型参数分别为`RequestConfig`、`Response`和`ResponseHeader`三个类型的值，用于在全局的拦截器中、method 实例配置中等地方将自动推断为请求适配器给定的类型。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/07-project/01-best-practice/01-manage-apis.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/tutorial/07-project/01-best-practice/01-manage-apis.md
@@ -73,7 +73,7 @@ export const orderAlova = createAlova({
 
 // upload alova instance
 export const uploadAlova = createAlova({
-  baseURL: 'https://api-order.alovajs.org',
+  baseURL: 'https://api-upload.alovajs.org',
   statesHook: VueHook,
   requestAdapter: axiosRequestAdapter()
 });


### PR DESCRIPTION
This PR applies the following fixes to the docs:

- changed `svelteAlova` to `solidAlova` in the Solid example
- replaced `alova` with `alovaInst` for consistency across the docs
- updated the mock baseURL in the `uploadAlova` instance from `https://api-order.alovajs.org` to `https://api-upload.alovajs.org`
- standardized import casing (e.g., `VueHook` instead of `vueHook`)
- capitalized type definitions for consistency with TypeScript conventions.